### PR TITLE
Add calendar program

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'optparse'
+
+options = OptionParser.new do |opts|
+  opts.banner = 'Usage: ruby cal.rb [options]'
+  opts.on('-m', 'Inspect month')
+  opts.on('-y', 'Inspect year')
+end
+
+begin
+  # Parse commandline
+  options.parse(ARGV)
+  # Hash. ex. {"m"=>"5", "y"=>"2021"}
+  year_month = ARGV.getopts('m:', 'y:')
+  p year_month
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
+  puts e.message
+  puts options.help
+  exit
+end
+
+# This year and this month if option is not defined
+year = year_month['y'] || Date.today.year
+month = year_month['m'] || Date.today.month
+
+# Validation of year
+if year.to_i.integer? && year.to_i.between?(1, 9999)
+  year = year.to_i
+else
+  puts "-y `#{year}` not in range 1..9999"
+  exit
+end
+
+# Validation of month
+if month.to_i.integer? && month.to_i.between?(1, 12)
+  month = month.to_i
+else
+  puts "-m  `#{month}` not in range 1..12"
+  exit
+end
+
+# Get last day of year month
+last_day = Date.new(year, month, -1).day
+
+# 0: Sun, 1: Mon, .... 6: Sat
+day_week = {}
+(1..last_day).each do |day|
+  week = Date.new(year, month, day).wday
+  day_week[day] = week
+end
+
+# Output Calendar: header
+week_str = 'Su Mo Tu We Th Fr Sa'
+puts "#{month}月 #{year}".center(week_str.length)
+puts week_str
+
+# Output Calendar: body
+day_week.each do |k, v|
+  # Indent of first week
+  print ' ' * 3 * v if k == 1
+
+  # Newline if the end is Sat
+  if v % 7 == 6
+    printf("%2d \n", k)
+  else
+    printf('%2d ', k)
+  end
+end

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -14,7 +14,6 @@ begin
   options.parse(ARGV)
   # Hash. ex. {"m"=>"5", "y"=>"2021"}
   year_month = ARGV.getopts('m:', 'y:')
-  p year_month
 rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
   puts e.message
   puts options.help
@@ -44,6 +43,7 @@ end
 # Get last day of year month
 last_day = Date.new(year, month, -1).day
 
+# key: day, value: week number like below.
 # 0: Sun, 1: Mon, .... 6: Sat
 day_week = {}
 (1..last_day).each do |day|


### PR DESCRIPTION
https://bootcamp.fjord.jp/practices/194

# 概要
こちらのプラクティスの提出です。

# 補足

> -mで月を、-yで年を指定できる

- `-m`, `-y` オプションのみ実装しています。
- `-m`, `-y` いづれかを省略した場合は、今月または今年と判断するようにしました。

例:
```bash
$ date
Fri Mar 26 13:46:07 JST 2021

$ ruby cal.rb -m 12
      12月 2021
Su Mo Tu We Th Fr Sa
          1  2  3  4
 5  6  7  8  9 10 11
12 13 14 15 16 17 18
19 20 21 22 23 24 25
26 27 28 29 30 31

$ ruby cal.rb -y 2100
      3月 2100
Su Mo Tu We Th Fr Sa
    1  2  3  4  5  6
 7  8  9 10 11 12 13
14 15 16 17 18 19 20
21 22 23 24 25 26 27
28 29 30 31
```

> 今日の日付の部分の色が反転する
> どのような引数が与えられようが、cal コマンドと同じ表示結果になる

こちらは実装していないです。

