### PR TITLE
Add nginx on EC2 settings with terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,9 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+
+# others
+.terraform
+*.tfstate*
+*.tfvars

--- a/99.others/practice-17/.terraform.lock.hcl
+++ b/99.others/practice-17/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.35.0"
+  constraints = "~> 3.25"
+  hashes = [
+    "h1:xOkRDvfIw457egXTu+4LAl7Kog31KKx339t8N+7TgPU=",
+    "zh:0b7cf15369fe940190f2e3fd77300119a16a9b821a7b15e049a6e349126b833d",
+    "zh:65680b35a45df6dc9ebe4439aa28dbe5767f8745443d0807656759d81ed23f5d",
+    "zh:75a71517d40b842308bc7a13a8dadcade99de3344292318b28a3ad95f09994e7",
+    "zh:865e618aa41f4a3842e818f6389f4aac89a985b409d1bb108ac753ea6292215d",
+    "zh:893658f93e57ea6c2bb458cdcf7d51e617147f53a9b2ed7741689bec3cfca4f9",
+    "zh:89d63eab0ad7fe3a891e6567052dd3227520ae48c212465d3a2b0bed326b319d",
+    "zh:94a408adcc52ce1758ecc2aad8394c35254029d18f358392b86602705a688b3d",
+    "zh:a82d09d03cb5480b3b4f318d1db3a64d80a701a429f3a84520e4a26f66b9a178",
+    "zh:aee92e745c43de2cc30913bddd8e625a8c6511f900f8e4104a0ccb746f276428",
+    "zh:b1178f4c2db30d7e49c3af441f79ac932bb5b8a8f05b0d770515b732ad4ac388",
+    "zh:b2684d0124ed6c394c83005def7387a6f8c9ac5f459dd7fc2fe56ea1aa97b20c",
+  ]
+}

--- a/99.others/practice-17/ec2.tf
+++ b/99.others/practice-17/ec2.tf
@@ -1,0 +1,82 @@
+data "aws_vpc" "this" {
+  id = var.vpc_id
+}
+
+data "aws_subnet" "this" {
+  id = var.subnet_id
+}
+
+data "aws_ami" "amazon-linux2" {
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-2.0.20210326.0-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "block-device-mapping.volume-type"
+    values = ["gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "this" {
+  name   = local.name
+  vpc_id = data.aws_vpc.this.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = local.name
+  }
+}
+
+resource "aws_instance" "this" {
+  ami           = data.aws_ami.amazon-linux2.id
+  instance_type = "t3.nano"
+
+  iam_instance_profile = aws_iam_instance_profile.this.name
+  vpc_security_group_ids = [
+    aws_security_group.this.id
+  ]
+
+  user_data = base64encode(templatefile("${path.module}/user_data.sh.tpl", { TARGET_DOMAIN = var.domain }))
+
+  tags = {
+    Name = local.name
+  }
+}

--- a/99.others/practice-17/iam.tf
+++ b/99.others/practice-17/iam.tf
@@ -1,0 +1,38 @@
+data "aws_iam_policy" "this" {
+  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role" "this" {
+  name = local.name
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "this" {
+  name   = local.name
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy.this.policy
+}
+
+
+resource "aws_iam_instance_profile" "this" {
+  name = local.name
+  role = aws_iam_role.this.name
+}
+
+

--- a/99.others/practice-17/locals.tf
+++ b/99.others/practice-17/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name = "nginx-practices"
+}

--- a/99.others/practice-17/provider.tf
+++ b/99.others/practice-17/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 0.14.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.25"
+    }
+  }
+}

--- a/99.others/practice-17/route53.tf
+++ b/99.others/practice-17/route53.tf
@@ -1,0 +1,19 @@
+data "aws_route53_zone" "this" {
+  name = var.domain
+}
+
+resource "aws_route53_record" "foo" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = "foo.${var.domain}"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_instance.this.public_ip]
+}
+
+resource "aws_route53_record" "bar" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = "bar.${var.domain}"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_instance.this.public_ip]
+}

--- a/99.others/practice-17/user_data.sh.tpl
+++ b/99.others/practice-17/user_data.sh.tpl
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -x
+exec > >(tee /var/log/user-data.log|logger -t user-data ) 2>&1
+
+amazon-linux-extras install nginx1 -y
+
+# foo.conf の配置
+cat << EOF > /etc/nginx/conf.d/foo.conf
+server {
+    listen       80;
+    server_name  foo.${TARGET_DOMAIN};
+
+    location / {
+        root   /usr/share/nginx/foo;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/foo;
+    }
+
+    access_log  /var/log/nginx/foo.access.log  main;
+    error_log  /var/log/nginx/foo.error.log warn;
+}
+
+server {
+    listen       443;
+    server_name  foo.${TARGET_DOMAIN};
+
+    ssl                  on;
+    ssl_certificate      /etc/nginx/server.crt;
+    ssl_certificate_key  /etc/nginx/server.key;
+
+    ssl_protocols        TLSv1.3 TLSv1.2 TLSv1.1;
+    ssl_ciphers          HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers   on;
+
+    location / {
+        root   /usr/share/nginx/foo;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/foo;
+    }
+
+    access_log  /var/log/nginx/foo.access.log  main;
+    error_log  /var/log/nginx/foo.error.log warn;
+}
+EOF
+
+# bar.conf の配置
+cat << EOF > /etc/nginx/conf.d/bar.conf
+server {
+    listen       80;
+    server_name  bar.${TARGET_DOMAIN};
+
+    location / {
+        root   /usr/share/nginx/bar;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/bar;
+    }
+
+    access_log  /var/log/nginx/bar.access.log  main;
+    error_log  /var/log/nginx/bar.error.log warn;
+}
+
+server {
+    listen       443;
+    server_name  bar.${TARGET_DOMAIN};
+
+    ssl                  on;
+    ssl_certificate      /etc/nginx/server.crt;
+    ssl_certificate_key  /etc/nginx/server.key;
+
+    ssl_protocols        TLSv1.3 TLSv1.2 TLSv1.1;
+    ssl_ciphers          HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers   on;
+
+    location / {
+        root   /usr/share/nginx/bar;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/bar;
+    }
+
+    access_log  /var/log/nginx/bar.access.log  main;
+    error_log  /var/log/nginx/bar.error.log warn;
+}
+EOF
+
+# 既存の設定をコピー
+cp -a /usr/share/nginx/html /usr/share/nginx/foo
+cp -a /usr/share/nginx/html /usr/share/nginx/bar
+
+# foo 用の HTML 配置
+cat << EOF > /usr/share/nginx/foo/index.html
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Foo</title>
+    </head>
+    <body>
+        <p>Foo Page</p>
+    </body>
+</html>
+EOF
+
+# bar 用の HTML 配置
+cat << EOF > /usr/share/nginx/bar/index.html
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Bar</title>
+    </head>
+    <body>
+        <p>Bar Page</p>
+    </body>
+</html>
+EOF
+
+openssl genrsa 2048 > /etc/nginx/server.key
+openssl req -new -subj "/C=JP/ST=Test/L=Test/O=Test/OU=Test/CN=*.${TARGET_DOMAIN}" -key /etc/nginx/server.key > /etc/nginx/server.csr
+openssl x509 -days 365 -req -signkey /etc/nginx/server.key < /etc/nginx/server.csr > /etc/nginx/server.crt
+
+service nginx start

--- a/99.others/practice-17/variables.tf
+++ b/99.others/practice-17/variables.tf
@@ -1,0 +1,11 @@
+variable "vpc_id" {
+  type    = string
+}
+
+variable "subnet_id" {
+  type    = string
+}
+
+variable "domain" {
+  type    = string
+}


### PR DESCRIPTION
https://bootcamp.fjord.jp/practices/17
https://bootcamp.fjord.jp/practices/19

# 概要

- Nginx で VirtualHost を実現します。
- foo と bar というサブドメインでホストしています。

# 前提

- すでに自身のドメインを持っている
- すでにAWSにアカウントがある
- すでに Route53 で NS の設定まで完了している。
- すでに IAM ユーザの設定が完了している。
- VPC や Subnet の設定が完了している。（ない場合はデフォルトのものでもOK）
- terraform がインストールされている。
  - https://learn.hashicorp.com/tutorials/terraform/install-cli

# terraform version

```
Terraform v0.14.5
```

# 使い方

## 準備

```
$ export AWS_DEFAULT_REGION="xxx"
$ export AWS_ACCESS_KEY_ID="xxx"
$ export AWS_SECRET_ACCESS_KEY="xxx"
```

## plan

作成するリソースの確認
```
$ terraform plan
```

## apply

リソースの作成

```
$ terraform apply
```

## 変数

plan/apply で変数を聞かれるので、代入する。

例:

```
$ terraform apply
var.domain
  Enter a value: example.com

var.subnet_id
  Enter a value: subnet-xxxxx

var.vpc_id
  Enter a value: vpc-xxxxx
```

# その他

今回 IAM ユーザの権限としては、 admin でやってます。
本番AWSアカウントなどは権限を絞る必要があります。